### PR TITLE
Expose java args

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,21 @@ humio_data_percentage: 80
 humio_data_secondary_path: ~
 humio_permissions: ~
 
+humio_java_opts_Xms: 4G
+humio_java_opts_Xmx: 32G
+humio_java_opts_Xss: 2M
+
+humio_java_opts:
+  - "-server"
+  - "-XX:+UseParallelOldGC"
+  - "-Xms{{ humio_java_opts_Xms }}"
+  - "-Xmx{{ humio_java_opts_Xmx }}"
+  - "-XX:MaxDirectMemorySize=64G"
+  - "-Xss{{ humio_java_opts_Xss }}"
+  - "-Xlog:gc*,gc+jni=debug:file=${HUMIO_DEBUGLOG_DIR}/gc_humio.log:time,tags:filecount=5,filesize=102400"
+  - "-Dhumio.auditlog.dir=${HUMIO_AUDITLOG_DIR}"
+  - "-Dhumio.debuglog.dir=${HUMIO_DEBUGLOG_DIR}"
+
 humio_filebeat_fields: {}
 humio_filebeat_tags: []
 

--- a/templates/humio@.service.j2
+++ b/templates/humio@.service.j2
@@ -12,7 +12,7 @@
   EnvironmentFile=/etc/humio/server_all.conf
   EnvironmentFile=/etc/humio/server_user_%i.conf
   WorkingDirectory={{ humio_data_path }}/{{ humio_host_id }}-%i
-  ExecStart=/usr/bin/numactl --cpunodebind=%i --membind=%i /usr/bin/java -server -XX:+UseParallelOldGC -Xms4G -Xmx32G -XX:MaxDirectMemorySize=64G -Xss2M -Xlog:gc*,gc+jni=debug:file=${HUMIO_DEBUGLOG_DIR}/gc_humio.log:time,tags:filecount=5,filesize=102400 -Dhumio.auditlog.dir=${HUMIO_AUDITLOG_DIR} -Dhumio.debuglog.dir=${HUMIO_DEBUGLOG_DIR} -jar /usr/lib/humio/server-{{ humio_version }}.jar
+  ExecStart=/usr/bin/numactl --cpunodebind=%i --membind=%i /usr/bin/java {{ humio_java_opts | join(" ") }} -jar /usr/lib/humio/server-{{ humio_version }}.jar
 
 [Install]
   WantedBy=default.target


### PR DESCRIPTION
I've been back and forth on a few options here and went for the bare minimum, which gives a lot of power (responsibility) to user but potentially also a pain to work with.

Alternative option is to have a few `humio_java_opts_` contexts for memory allocation, GC, logging etc. I.e
```yaml
humio_java_opts:
  - "-server"
  - "-Dhumio.auditlog.dir=${HUMIO_AUDITLOG_DIR}"
  - "-Dhumio.debuglog.dir=${HUMIO_DEBUGLOG_DIR}"
humio_java_opts_gc:
  - "-XX:+UseParallelOldGC"
humio_java_opts_mem:
  - "-Xms{{ humio_java_opts_Xms }}"
  - "-Xmx{{ humio_java_opts_Xmx }}"
  - "-XX:MaxDirectMemorySize=64G"
  - "-Xss{{ humio_java_opts_Xss }}"
```
Which are then finally joined together in systemd unit config
```
ExecStart=/usr/bin/numactl --cpunodebind=%i --membind=%i /usr/bin/java {{ humio_java_opts | join(" ") }} {{ humio_java_opts_gc | join(" ") }} {{ humio_java_opts_mem | join(" ") }} -jar /usr/lib/humio/server-{{ humio_version }}.jar
```