### PR TITLE
Set correct permissions on view-group-permissions.json

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,18 +130,6 @@
     owner: humio
     group: humio
   with_dict: "{{ ansible_local.cpusockets }}"
-  when: humio_permissions_path is undefined
-
-- name: Copy permissions
-  tags: humio-permissions
-  copy:
-    src: "{{ humio_permissions_path }}"
-    dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data/view-group-permissions.json"
-    mode: 0644
-    owner: humio
-    group: humio
-  with_dict: "{{ ansible_local.cpusockets }}"
-  when: humio_permissions_path is defined
 
 - name: Install Humioctl version {{ humioctl_version }}
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,6 +130,18 @@
     owner: humio
     group: humio
   with_dict: "{{ ansible_local.cpusockets }}"
+  when: humio_permissions_path is undefined
+
+- name: Copy permissions
+  tags: humio-permissions
+  copy:
+    src: "{{ humio_permissions_path }}"
+    dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data/view-group-permissions.json"
+    mode: 0644
+    owner: humio
+    group: humio
+  with_dict: "{{ ansible_local.cpusockets }}"
+  when: humio_permissions_path is defined
 
 - name: Install Humioctl version {{ humioctl_version }}
   block:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -126,6 +126,9 @@
   copy:
     content: "{{ humio_permissions | default('{}') }}"
     dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data/view-group-permissions.json"
+    mode: 0644
+    owner: humio
+    group: humio
   with_dict: "{{ ansible_local.cpusockets }}"
 
 - name: Install Humioctl version {{ humioctl_version }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -127,8 +127,6 @@
     content: "{{ humio_permissions | default('{}') }}"
     dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data/view-group-permissions.json"
     mode: 0644
-    owner: humio
-    group: humio
   with_dict: "{{ ansible_local.cpusockets }}"
 
 - name: Install Humioctl version {{ humioctl_version }}


### PR DESCRIPTION
The `view-group-permissions.json` file was getting created with `root` as the owner and `0600` permissions. This caused the file to be unreadable by Humio.

@mwl As an aside, would it make sense to allow the end-user of the playbook to specify a path for the file rather than having to dump the contents in-line? These files can get rather large.