### PR TITLE
Update ansible-galaxy metadata

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: Apache
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.6
 
   platforms:
   - name: EL

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,9 @@ galaxy_info:
 
   galaxy_tags:
   - monitoring
+  - logging
+  - system
+  - humio
 
 dependencies:
   - role: humio.java

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,10 @@ galaxy_info:
   - name: EL
     versions:
     - 7
+  - name: Ubuntu
+    versions:
+    - xenial
+    - bionic
 
   galaxy_tags:
   - monitoring

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: Martin Westergaard Lassen
   description: Humio Ansible role


### PR DESCRIPTION
Fixed a few things in the metadata:

* Increased minimum ansible version to 2.6 (lower than that won't work due to `dict2items` usage in the playbooks)
* Added Ubuntu to the list of supported platforms.
* Added some additional tags

@mwl Any thoughts on the platforms section? I've personally tested it on bionic. I haven't tested it on xenial, but don't see why it wouldn't work. Would it be worth doing a more comprehensive sweep to see what works and what doesn't?