### PR TITLE
Make it smarter about NUMA nodes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ humio_data_path: "/var/humio"
 humio_data_percentage: 80
 humio_data_secondary_path: ~
 humio_permissions: ~
+humio_processes: "{{ ansible_local.numanodes | length }}"
 
 humio_java_opts_Xms: 4G
 humio_java_opts_Xmx: 32G

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,16 +5,16 @@
 
 - name: Stop all Humio instances
   service:
-    name: "humio@{{ item.key }}"
+    name: "humio@{{ item }}"
     daemon_reload: yes
     enabled: yes
     state: stopped
-  loop: "{{ ansible_local.cpusockets|dict2items }}"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   listen: Restart Humio
 
 - name: Start all Humio instances
   service:
-    name: "humio@{{ item.key }}"
+    name: "humio@{{ item }}"
     state: started
-  loop: "{{ ansible_local.cpusockets|dict2items }}"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   listen: Restart Humio

--- a/tasks/custom_facts.yml
+++ b/tasks/custom_facts.yml
@@ -16,4 +16,20 @@
   check_mode: no
   notify: Collect facts
 
+- name: NUMA node fact
+  copy:
+    content: |
+      #!/bin/bash
+      export LC_ALL=en_GB.UTF8
+      for socket in $(/usr/bin/lscpu --all --parse=node,socket | grep -E "[0-9]$" | cut -d, -f2 | sort | uniq); do
+        echo "[$socket]"
+        echo "nodes="$(/usr/bin/lscpu --all --parse=node,socket | grep -E "${socket}$" | cut -d, -f1 | sort -n | uniq | paste -sd ',' -)
+        echo
+      done
+    dest: "/etc/ansible/facts.d/numanodes.fact"
+    mode: "0755"
+  check_mode: no
+  notify: Collect facts
+
+
 - meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -109,7 +109,7 @@
 - name: Humio user-instance configuration file
   tags: humio-conf
   copy:
-    content: "{{ humio_config[item] | default('# Empty') }}"
+    content: "{{ humio_config[item|string] | default('# Empty') }}"
     dest: "/etc/humio/server_user_{{ item }}.conf"
   loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,32 +35,32 @@
 
 - name: Create Humio directories
   file:
-    path: "/var/log/humio/{{ item.key }}"
+    path: "/var/log/humio/{{ item }}"
     state: directory
     owner: "humio"
     group: "humio"
     mode: 0750
-  with_dict: "{{ ansible_local.cpusockets }}"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
 
 - name: Create Humio Data directories
   file:
-    path: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data"
+    path: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item }}/data"
     state: directory
     owner: "humio"
     group: "humio"
     mode: 0755
-  with_dict: "{{ ansible_local.cpusockets }}"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
 
 - name: Create Humio secondary directories
   file:
-    path: "{{ humio_data_secondary_path }}/{{ humio_host_id }}-{{ item.key }}/data"
+    path: "{{ humio_data_secondary_path }}/{{ humio_host_id }}-{{ item }}/data"
     state: directory
     owner: "humio"
     group: "humio"
     mode: 0755
-  with_dict: "{{ ansible_local.cpusockets }}"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
   when: humio_data_secondary_path is defined
 
@@ -95,8 +95,8 @@
   tags: humio-conf
   template:
     src: server.conf.j2
-    dest: "/etc/humio/server_{{ item.key }}.conf"
-  with_dict: "{{ ansible_local.cpusockets }}"
+    dest: "/etc/humio/server_{{ item }}.conf"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
 
 - name: Humio user configuration file
@@ -109,25 +109,26 @@
 - name: Humio user-instance configuration file
   tags: humio-conf
   copy:
-    content: "{{ humio_config[item.key] | default('# Empty') }}"
-    dest: "/etc/humio/server_user_{{ item.key }}.conf"
-  with_dict: "{{ ansible_local.cpusockets }}"
+    content: "{{ humio_config[item] | default('# Empty') }}"
+    dest: "/etc/humio/server_user_{{ item }}.conf"
+  loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
 
 - name: Create Humio SystemD template configuration
   tags: humio-update
   template:
     src: "humio@.service.j2"
-    dest: /etc/systemd/system/humio@.service
+    dest: /etc/systemd/system/humio@{{ item }}.service
+  loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
 
 - name: Copy permissions
   tags: humio-permissions
   copy:
     content: "{{ humio_permissions | default('{}') }}"
-    dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data/view-group-permissions.json"
+    dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item }}/data/view-group-permissions.json"
     mode: 0644
-  with_dict: "{{ ansible_local.cpusockets }}"
+  loop: "{{ range(0, humio_processes|int)|list }}"
 
 - name: Install Humioctl version {{ humioctl_version }}
   block:

--- a/templates/cpuaffinity.conf.j2
+++ b/templates/cpuaffinity.conf.j2
@@ -1,5 +1,0 @@
-[Unit]
-{% if item.key|int > 0 %}  After=humio@{{ item.key|int - 1}}.service{% endif %}
-
-[Service]
-  CPUAffinity={{ item.value.vcpus }}

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,14 +1,14 @@
 ---
 
-{% for item in ansible_local.cpusockets|dict2items -%}
+{% for item in range(0, humio_processes|int)|list -%}
 - type: log
   paths:
-  - /var/log/humio/{{ item.key }}/humio-debug.log
-  - /var/log/humio/{{ item.key }}/humio-threaddumps.log
-  - /var/log/humio/{{ item.key }}/humio-metrics.log
+  - /var/log/humio/{{ item }}/humio-debug.log
+  - /var/log/humio/{{ item }}/humio-threaddumps.log
+  - /var/log/humio/{{ item }}/humio-metrics.log
   fields:
     '@type': 'humio'
-    '@humionode': "{{ "%d%02d" | format(humio_host_id|int, item.key|int) }}"
+    '@humionode': "{{ "%d%02d" | format(humio_host_id|int, item) }}"
     {% for field in humio_filebeat_fields|dict2items -%}
     '{{ field.key }}': '{{ field.value }}'
     {% endfor -%}
@@ -19,10 +19,10 @@
     match: after
 - type: log
   paths:
-  - /var/log/humio/{{ item.key }}/gc_humio.log
+  - /var/log/humio/{{ item }}/gc_humio.log
   fields:
     '@type': 'humio-gc'
-    '@humionode': "{{ "%d%02d" | format(humio_host_id|int, item.key|int) }}"
+    '@humionode': "{{ "%d%02d" | format(humio_host_id|int, item) }}"
     {% for field in humio_filebeat_fields|dict2items -%}
     '{{ field.key }}': '{{ field.value }}'
     {% endfor -%}

--- a/templates/humio@.service.j2
+++ b/templates/humio@.service.j2
@@ -8,11 +8,11 @@
   User=humio
   Group=humio
   LimitNOFILE=250000:250000
-  EnvironmentFile=/etc/humio/server_%i.conf
+  EnvironmentFile=/etc/humio/server_{{ item }}.conf
   EnvironmentFile=/etc/humio/server_all.conf
-  EnvironmentFile=/etc/humio/server_user_%i.conf
-  WorkingDirectory={{ humio_data_path }}/{{ humio_host_id }}-%i
-  ExecStart=/usr/bin/numactl --cpunodebind=%i --membind=%i /usr/bin/java {{ humio_java_opts | join(" ") }} -jar /usr/lib/humio/server-{{ humio_version }}.jar
+  EnvironmentFile=/etc/humio/server_user_{{ item }}.conf
+  WorkingDirectory={{ humio_data_path }}/{{ humio_host_id }}-{{ item }}
+  ExecStart=/usr/bin/numactl --cpunodebind={{ ansible_local.numanodes[item|string].nodes }} --membind={{ ansible_local.numanodes[item|string].nodes }} /usr/bin/java {{ humio_java_opts | join(" ") }} -jar /usr/lib/humio/server-{{ humio_version }}.jar
 
 [Install]
   WantedBy=default.target

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,17 +1,17 @@
 #jinja2: trim_blocks:False
-BOOTSTRAP_HOST_ID={{ "%d%02d" | format(humio_host_id|int, item.key|int) }}
-DIRECTORY={{ humio_data_path }}/{{ humio_host_id }}-{{ item.key }}/data
+BOOTSTRAP_HOST_ID={{ "%d%02d" | format(humio_host_id|int, item) }}
+DIRECTORY={{ humio_data_path }}/{{ humio_host_id }}-{{ item }}/data
 {%- if humio_data_secondary_path %}
 PRIMARY_STORAGE_PERCENTAGE={{ humio_data_percentage }}
-SECONDARY_DATA_DIRECTORY={{ humio_data_secondary_path }}/{{ humio_host_id }}-{{ item.key }}/data
+SECONDARY_DATA_DIRECTORY={{ humio_data_secondary_path }}/{{ humio_host_id }}-{{ item }}/data
 {%- endif %}
-HUMIO_AUDITLOG_DIR=/var/log/humio/{{ item.key }}
-HUMIO_DEBUGLOG_DIR=/var/log/humio/{{ item.key }}
-HUMIO_PORT={{ 8080 + item.key|int }}
-ELASTIC_PORT={{ 9200 + item.key|int }}
+HUMIO_AUDITLOG_DIR=/var/log/humio/{{ item }}
+HUMIO_DEBUGLOG_DIR=/var/log/humio/{{ item }}
+HUMIO_PORT={{ 8080 + item }}
+ELASTIC_PORT={{ 9200 + item }}
 ZOOKEEPER_URL={% for host in zookeeper_hosts | sort(attribute="ip") %}{{ host.ip }}:{{ host.port | default('2181') }}{% if not loop.last %},{% endif %}{% endfor %}
 KAFKA_SERVERS={% for host in kafka_hosts | sort(attribute="ip") %}{{ host.ip }}:{{ host.port | default('9092') }}{% if not loop.last %},{% endif %}{% endfor %}
-EXTERNAL_URL=http://{{ ansible_default_ipv4['address'] }}:{{ 8080 + item.key|int }}
+EXTERNAL_URL=http://{{ ansible_default_ipv4['address'] }}:{{ 8080 + item }}
 PUBLIC_URL={{ humio_public_url }}
 
 HUMIO_SOCKET_BIND={{ humio_socket_bind }}


### PR DESCRIPTION
We previously assumed that the number of NUMA nodes directly correlated with the number of CPU sockets. This isn't always the case – notably AMD EPYC processors tend to have more NUMA nodes than sockets. The change here will correctly identify how many actual CPU sockets there are and determine the NUMA nodes that are associated with each. It will then spin up a Humio process for each socket and assign appropriate `numactl` settings accordingly.