### PR TITLE
Bump humio.java dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,4 +25,4 @@ galaxy_info:
 
 dependencies:
   - role: humio.java
-    version: 0.1.0
+    version: 0.2.0


### PR DESCRIPTION
Bumps the `humio.java` dependency to the latest version that switches to using apt/yum repos rather than fetching the rpm/deb.