### PR TITLE
Make memory settings easier to configure

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ humio_host_id: 0
 humio_public_url: "http://{{ ansible_default_ipv4.address }}"
 humio_socket_bind: "0.0.0.0"
 humio_http_bind: "{{ ansible_eth0.ipv4.address }}"
+humio_total_memory: 64
 humio_config:
   all: |
     AUTHENTICATION_METHOD=byproxy
@@ -33,6 +34,12 @@ zookeeper_hosts:
 kafka_hosts:
   - ip: "{{ ansible_default_ipv4.address }}"
 ```
+
+`humio_total_memory` should be the total amount of memory on the system you're installing
+Humio on. The JVM memory settings will be determined automatically based on that number
+using our [recommended formula](https://docs.humio.com/operations-guide/configuration/basic-configuration/jvm-configuration/#java-memory-options).
+If you want more fine-grained control, you can set the JVM memory options individually. See
+the `defaults/main.yml` file for which variables to override.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ humio_host_id: 0
 humio_public_url: "http://{{ ansible_default_ipv4.address }}"
 humio_socket_bind: "0.0.0.0"
 humio_http_bind: "{{ ansible_eth0.ipv4.address }}"
-humio_total_memory: 64
 humio_config:
   all: |
     AUTHENTICATION_METHOD=byproxy

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ kafka_hosts:
   - ip: "{{ ansible_default_ipv4.address }}"
 ```
 
-`humio_total_memory` should be the total amount of memory on the system you're installing
-Humio on. The JVM memory settings will be determined automatically based on that number
-using our [recommended formula](https://docs.humio.com/operations-guide/configuration/basic-configuration/jvm-configuration/#java-memory-options).
+`humio_total_memory_mb` can be used to override the memory used by Humio. This defaults to
+using all memory available on the machine. The JVM memory settings will be determined automatically
+based on that number using our [recommended formula](https://docs.humio.com/operations-guide/configuration/basic-configuration/jvm-configuration/#java-memory-options).
 If you want more fine-grained control, you can set the JVM memory options individually. See
 the `defaults/main.yml` file for which variables to override.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,20 +12,21 @@ humio_data_secondary_path: ~
 humio_permissions: ~
 humio_processes: "{{ ansible_local.numanodes | length }}"
 
-# Default memory options configured for a machine with 64G of
-# memory. You can adjust the default by overriding `humio_total_memory`
-# or for more fine-grained control you can override the
-# `humio_java_opts_*` variables directly. See the docs for more details
-# about JVM memory usage:
+# By default, the amount of memory on the system is discovered by Ansible
+# and that number is used to calculate all others. You can manually set the
+# total amount in MB that will be used for that calculation by setting
+# `humio_total_memory_mb`. If you want to tweak these in a more fine-grained
+# way, you can set the `humio_java_opts_*` values individually.
+# See the docs for more details about JVM memory usage:
 # https://docs.humio.com/operations-guide/configuration/basic-configuration/jvm-configuration/#java-memory-options
-humio_total_memory: 64
-humio_total_memory_per_process: "{{ (humio_total_memory|int / humio_processes|int)|int }}"
-humio_memory_allocation: "{{ (humio_total_memory_per_process|int / 4)|int }}"
+humio_total_memory_mb: "{{ ansible_memtotal_mb|int }}"
+humio_total_memory_per_process_mb: "{{ (humio_total_memory_mb|int / humio_processes|int)|int }}"
+humio_memory_allocation_mb: "{{ (humio_total_memory_per_process_mb|int / 4)|int }}"
 
 humio_java_opts_Xss: 2M
-humio_java_opts_Xms: "{{ humio_memory_allocation }}G"
-humio_java_opts_Xmx: "{{ humio_memory_allocation }}G"
-humio_java_opts_MaxDirectMemorySize: "{{ humio_memory_allocation }}G"
+humio_java_opts_Xms: "{{ humio_memory_allocation_mb }}M"
+humio_java_opts_Xmx: "{{ humio_memory_allocation_mb }}M"
+humio_java_opts_MaxDirectMemorySize: "{{ humio_memory_allocation_mb }}M"
 
 humio_java_opts:
   - "-server"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,11 @@ humio_data_secondary_path: ~
 humio_permissions: ~
 humio_processes: "{{ ansible_local.numanodes | length }}"
 
-# Default memory options configured for a single Humio process
-# running on a 64G machine. You can adjust the default by
-# overriding humio_total_memory or for more fine-grained control
-# you can override the humio_java_opts_* variables directly.
-# See the docs for more details about JVM memory usage:
+# Default memory options configured for a machine with 64G of
+# memory. You can adjust the default by overriding `humio_total_memory`
+# or for more fine-grained control you can override the
+# `humio_java_opts_*` variables directly. See the docs for more details
+# about JVM memory usage:
 # https://docs.humio.com/operations-guide/configuration/basic-configuration/jvm-configuration/#java-memory-options
 humio_total_memory: 64
 humio_total_memory_per_process: "{{ (humio_total_memory|int / humio_processes|int)|int }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,16 +12,27 @@ humio_data_secondary_path: ~
 humio_permissions: ~
 humio_processes: "{{ ansible_local.numanodes | length }}"
 
-humio_java_opts_Xms: 4G
-humio_java_opts_Xmx: 32G
+# Default memory options configured for a single Humio process
+# running on a 64G machine. You can adjust the default by
+# overriding humio_total_memory or for more fine-grained control
+# you can override the humio_java_opts_* variables directly.
+# See the docs for more details about JVM memory usage:
+# https://docs.humio.com/operations-guide/configuration/basic-configuration/jvm-configuration/#java-memory-options
+humio_total_memory: 64
+humio_total_memory_per_process: "{{ (humio_total_memory|int / humio_processes|int)|int }}"
+humio_memory_allocation: "{{ (humio_total_memory_per_process|int / 4)|int }}"
+
 humio_java_opts_Xss: 2M
+humio_java_opts_Xms: "{{ humio_memory_allocation }}G"
+humio_java_opts_Xmx: "{{ humio_memory_allocation }}G"
+humio_java_opts_MaxDirectMemorySize: "{{ humio_memory_allocation }}G"
 
 humio_java_opts:
   - "-server"
   - "-XX:+UseParallelOldGC"
   - "-Xms{{ humio_java_opts_Xms }}"
   - "-Xmx{{ humio_java_opts_Xmx }}"
-  - "-XX:MaxDirectMemorySize=64G"
+  - "-XX:MaxDirectMemorySize={{ humio_java_opts_MaxDirectMemorySize }}"
   - "-Xss{{ humio_java_opts_Xss }}"
   - "-Xlog:gc*,gc+jni=debug:file=${HUMIO_DEBUGLOG_DIR}/gc_humio.log:time,tags:filecount=5,filesize=102400"
   - "-Dhumio.auditlog.dir=${HUMIO_AUDITLOG_DIR}"


### PR DESCRIPTION
This builds our default recommended memory allocation calculation into the ansible role. Now you simply specify the total memory on the machines you're installing Humio on and the rest is determined for you under-the-hood. You're still able to manually override each individual setting if desired though.