### PR TITLE
Add support for multiple data paths

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ humio_data_path: "/var/humio"
 #  "1": "/data/humio1"
 #
 # If you use this, then you will likely also need to update the
-# `humio_systemd_working_dir` variable below.
+# `humio_working_dir` variable below.
 humio_data_paths:
   "0": "{{ humio_data_path }}"
   "1": "{{ humio_data_path }}"
@@ -31,10 +31,10 @@ humio_data_paths:
 # if you have two partitions (`/data/humio0` and `/data/humio1`), you would set
 # this to:
 #
-# humio_systemd_working_dir: "/data/humio%i/{{ humio_host_id }}-%i"
+# humio_working_dir: "/data/humio%i/{{ humio_host_id }}-%i"
 #
 # Keeping the `/{{ humio_host_id }}-%i` bit at the end is important.
-humio_systemd_working_dir: "{{ humio_data_path }}/{{ humio_host_id }}-%i"
+humio_working_dir: "{{ humio_data_path }}/{{ humio_host_id }}-%i"
 
 humio_data_percentage: 80
 humio_data_secondary_path: ~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,35 @@ humio_public_url: "http://{{ ansible_default_ipv4.address }}"
 humio_socket_bind: "0.0.0.0"
 humio_http_bind: "0.0.0.0"
 humio_data_path: "/var/humio"
+
+# This exists for specific situations where someone may have different
+# base locations for each Humio process running on the system. Under
+# most conditions this can be left at the defaults where it simply mirrors
+# `humio_data_path` – which is typically a single directory that both
+# processes have as a shared base directory. For example, if you have
+# two partitions (`/data/humio0` and `/data/humio1`), you would set this to:
+#
+# humio_data_paths:
+#  "0": "/data/humio0"
+#  "1": "/data/humio1"
+#
+# If you use this, then you will likely also need to update the
+# `humio_systemd_working_dir` variable below.
+humio_data_paths:
+  "0": "{{ humio_data_path }}"
+  "1": "{{ humio_data_path }}"
+
+# This will typically only be modified in situations where humio_data_paths
+# is also modified. When working with this, use `%i` to represent the Humio
+# process number (generally this will evaluate to either 0 or 1). For example,
+# if you have two partitions (`/data/humio0` and `/data/humio1`), you would set
+# this to:
+#
+# humio_systemd_working_dir: "/data/humio%i/{{ humio_host_id }}-%i"
+#
+# Keeping the `/{{ humio_host_id }}-%i` bit at the end is important.
+humio_systemd_working_dir: "{{ humio_data_path }}/{{ humio_host_id }}-%i"
+
 humio_data_percentage: 80
 humio_data_secondary_path: ~
 humio_permissions: ~

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,7 +45,7 @@
 
 - name: Create Humio Data directories
   file:
-    path: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item }}/data"
+    path: "{{ humio_data_paths[item|string] }}/{{ humio_host_id }}-{{ item }}/data"
     state: directory
     owner: "humio"
     group: "humio"
@@ -142,7 +142,7 @@
   tags: humio-permissions
   copy:
     content: "{{ humio_permissions | default('{}') }}"
-    dest: "{{ humio_data_path }}/{{ humio_host_id }}-{{ item }}/data/view-group-permissions.json"
+    dest: "{{ humio_data_paths[item|string] }}/{{ humio_host_id }}-{{ item }}/data/view-group-permissions.json"
     mode: 0644
   loop: "{{ range(0, humio_processes|int)|list }}"
 

--- a/templates/humio@.service.j2
+++ b/templates/humio@.service.j2
@@ -16,7 +16,7 @@
   EnvironmentFile=/etc/humio/server_%i.conf
   EnvironmentFile=/etc/humio/server_all.conf
   EnvironmentFile=/etc/humio/server_user_%i.conf
-  WorkingDirectory={{ humio_systemd_working_dir }}
+  WorkingDirectory={{ humio_working_dir }}
   ExecStart=/usr/bin/numactl --cpunodebind=${NUMA_NODES} --membind=${NUMA_NODES} /usr/bin/java {{ humio_java_opts | join(" ") }} -jar /usr/lib/humio/server-{{ humio_version }}.jar
 
 [Install]

--- a/templates/humio@.service.j2
+++ b/templates/humio@.service.j2
@@ -16,7 +16,7 @@
   EnvironmentFile=/etc/humio/server_%i.conf
   EnvironmentFile=/etc/humio/server_all.conf
   EnvironmentFile=/etc/humio/server_user_%i.conf
-  WorkingDirectory={{ humio_data_path }}/{{ humio_host_id }}-%i
+  WorkingDirectory={{ humio_systemd_working_dir }}
   ExecStart=/usr/bin/numactl --cpunodebind=${NUMA_NODES} --membind=${NUMA_NODES} /usr/bin/java {{ humio_java_opts | join(" ") }} -jar /usr/lib/humio/server-{{ humio_version }}.jar
 
 [Install]

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -1,6 +1,6 @@
 #jinja2: trim_blocks:False
 BOOTSTRAP_HOST_ID={{ "%d%02d" | format(humio_host_id|int, item) }}
-DIRECTORY={{ humio_data_path }}/{{ humio_host_id }}-{{ item }}/data
+DIRECTORY={{ humio_data_paths[item|string] }}/{{ humio_host_id }}-{{ item }}/data
 {%- if humio_data_secondary_path %}
 PRIMARY_STORAGE_PERCENTAGE={{ humio_data_percentage }}
 SECONDARY_DATA_DIRECTORY={{ humio_data_secondary_path }}/{{ humio_host_id }}-{{ item }}/data


### PR DESCRIPTION
This adds support for situations where you're running multiple Humio processes on the same machine, but they each have different data partitions. It allows you to override those with `humio_data_paths` (note the plural) and `humio_systemd_working_dir`. Typical installations will not need to modify these and it's backward compatible, so if you're currently only setting `humio_data_path` everything will continue working (and that's all that should be needed for most installations really).