### PR TITLE
Cleanup old, defunct systemd unit files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -138,6 +138,20 @@
   loop: "{{ range(0, humio_processes|int)|list }}"
   notify: Restart Humio
 
+# This needs to stay in place for anyone who performed a run
+# using version 0.2.19, 0.2.20, or 0.2.21 and is now performing
+# a run with 0.3.0+. Those versions dropped non-template unit
+# files for Humio that will cause issues on newer versions that
+# have switched back to using a systemd unit template file. This
+# will be a no-op on systems where these files don't exist.
+- name: Cleanup old, defunct SystemD unit files
+  tags: humio-update
+  file:
+    path: /etc/systemd/system/humio@{{ item }}.service
+    state: absent
+  loop: "{{ range(0, humio_processes|int)|list }}"
+  notify: Restart Humio
+
 - name: Copy permissions
   tags: humio-permissions
   copy:


### PR DESCRIPTION
This adds a task to cleanup the now defunct systemd unit files that were dropped in versions 0.2.19, 0.2.20, and 0.2.21 of this role. Newer versions of the role have switched back to using a systemd unit template file and having both in place would cause problems. This ensures that won't happen.