### PR TITLE
Adding config vars for Humio caching

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,10 @@ humio_working_dir: "{{ humio_data_path }}/{{ humio_host_id }}-%i"
 
 humio_data_percentage: 80
 humio_data_secondary_path: ~
+
+humio_cache_percentage: 90
+humio_cache_path: ~
+
 humio_permissions: ~
 humio_processes: "{{ ansible_local.numanodes | length }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -64,6 +64,17 @@
   notify: Restart Humio
   when: humio_data_secondary_path is defined
 
+- name: Create Humio cache directories
+  file:
+    path: "{{ humio_cache_path }}/{{ humio_host_id }}-{{ item }}"
+    state: directory
+    owner: "humio"
+    group: "humio"
+    mode: 0755
+  loop: "{{ range(0, humio_processes|int)|list }}"
+  notify: Restart Humio
+  when: humio_cache_path is defined
+
 - name: Download Humio jar
   tags: humio-update
   check_mode: no

--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -5,6 +5,10 @@ DIRECTORY={{ humio_data_paths[item|string] }}/{{ humio_host_id }}-{{ item }}/dat
 PRIMARY_STORAGE_PERCENTAGE={{ humio_data_percentage }}
 SECONDARY_DATA_DIRECTORY={{ humio_data_secondary_path }}/{{ humio_host_id }}-{{ item }}/data
 {%- endif %}
+{%- if humio_cache_path %}
+CACHE_STORAGE_DIRECTORY={{ humio_cache_path }}
+CACHE_STORAGE_PERCENTAGE={{ humio_cache_percentage }}
+{%- endif %}
 HUMIO_AUDITLOG_DIR=/var/log/humio/{{ item }}
 HUMIO_DEBUGLOG_DIR=/var/log/humio/{{ item }}
 HUMIO_PORT={{ 8080 + item }}


### PR DESCRIPTION
Still a bit unsure if these parameters should be prefixed with `humio_data_`. The argument for not doing it is that it is _not_ data. On the other hand it is still something in the storage section.