### PR TITLE
Humio version upgrade, add upgrade handlers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 humio_host_id: 0
-humio_version: 1.16.1
+humio_version: 1.18.0
 humioctl_version: 0.27.0
 humio_mirror: https://repo.humio.com/repository/maven-public
 humio_public_url: "http://{{ ansible_default_ipv4.address }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,6 +11,7 @@
     state: stopped
   loop: "{{ range(0, humio_processes|int)|list }}"
   listen: Restart Humio
+  when: humio_upgrade is not defined
 
 - name: Start all Humio instances
   service:
@@ -18,3 +19,33 @@
     state: started
   loop: "{{ range(0, humio_processes|int)|list }}"
   listen: Restart Humio
+  when: humio_upgrade is not defined
+
+- name:  Restart Humio service
+  throttle: "{{ deploy_concurrency | int }}"
+  service:
+    name: "humio@{{ item }}"
+    state: restarted
+    daemon_reload: yes
+  loop: "{{ range(0, humio_processes|int)|list }}"
+  listen: Restart Humio
+  when: humio_upgrade is defined and humio_shutdown == false
+
+- name:  Stop all Humio instances - upgrade mode
+  service:
+    name: "humio@{{ item }}"
+    state: restarted
+    daemon_reload: yes
+  loop: "{{ range(0, humio_processes|int)|list }}"
+  listen: Restart Humio
+  when: humio_upgrade is defined and humio_shutdown == true
+
+- name:  Started all Humio instances - upgrade mode
+  service:
+    name: "humio@{{ item }}"
+    state: restarted
+    daemon_reload: yes
+  loop: "{{ range(0, humio_processes|int)|list }}"
+  listen: Restart Humio
+  when: humio_upgrade is defined and humio_shutdown == true
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: Apache
 
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   platforms:
   - name: EL

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-
+shutdown_humio: false
 humio_filebeat_default_tags:
   - "@host"
   - "@type"


### PR DESCRIPTION
The role now requires Ansible 2.9 to support the usage of throttle in the handler.
Bump Humio version to latest stable.
Bump minimum Ansible version to 2.9.