### PR TITLE
Fixes handler in some ansible versions

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -29,7 +29,7 @@
     daemon_reload: yes
   loop: "{{ range(0, humio_processes|int)|list }}"
   listen: Restart Humio
-  when: humio_upgrade is defined and not humio_shutdown
+  when: deploy_concurrency is defined and humio_upgrade is defined and not humio_shutdown
 
 - name:  Stop all Humio instances - upgrade mode
   service:


### PR DESCRIPTION
Needed to limit the handler when deploy_concurrency not set.